### PR TITLE
Implement history and add keyboard shorcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
       "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
@@ -3288,6 +3289,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -5491,6 +5493,7 @@
       "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },

--- a/qui-code-block.js
+++ b/qui-code-block.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import {EditorState} from "@codemirror/state";
 import {EditorView, lineNumbers, keymap, highlightActiveLineGutter, highlightSpecialChars } from "@codemirror/view";
-import {defaultKeymap, indentWithTab} from "@codemirror/commands";
+import {defaultKeymap, indentWithTab, undo, redo, history} from "@codemirror/commands";
 import {autocompletion} from '@codemirror/autocomplete';
 import { xml } from '@codemirror/lang-xml';
 import { javascript } from '@codemirror/lang-javascript';
@@ -41,8 +41,8 @@ class QuiCodeBlock extends LitElement {
             display: block;
             height: 100%;
         }
-
-        #codeMirrorContainer {
+        
+        #codeMirrorContainer, .cm-editor {
             height: 100%;
         }
 
@@ -159,6 +159,7 @@ class QuiCodeBlock extends LitElement {
         };
 
         const conf = [
+            history(),
             this._detectMode(), 
             this._basicTheme,
             highlightActiveLineGutter(),
@@ -168,8 +169,11 @@ class QuiCodeBlock extends LitElement {
             keymap.of([
                 { key: "Shift-Enter", run: shiftEnterCommand },
                 indentWithTab,
-                ...defaultKeymap
-              ]),
+                ...defaultKeymap,
+                { key: "Mod-z", run: undo },      // Undo
+                { key: "Mod-y", run: redo },      // Redo
+                { key: "Mod-Shift-z", run: redo } // Redo (macOS)
+            ]),
             EditorView.updateListener.of((update) => {
                 if (update.docChanged) {
                     const value = update.state.doc.toString();


### PR DESCRIPTION
Also add 100% height to .cm-editor to allow looking like this:
<img width="1738" height="1142" alt="image" src="https://github.com/user-attachments/assets/c3a31d3d-d84a-41ba-8338-09994119ce5d" />
